### PR TITLE
Fixing for working

### DIFF
--- a/Dangerfile.default
+++ b/Dangerfile.default
@@ -1,3 +1,5 @@
 danger.import_dangerfile(github: "yahoojapan/hosted-danger", path: "plugins/Dangerfile")
 
 common_rule.check
+
+message "Hello from Hosted Danger :sunny:"

--- a/Dangerfile.default
+++ b/Dangerfile.default
@@ -1,3 +1,3 @@
-danger.import_dangerfile(github: "hosted-danger/dangerfile")
+danger.import_dangerfile(github: "yahoojapan/hosted-danger", path: "plugins/Dangerfile")
 
 common_rule.check

--- a/src/hosted-danger/modules/server_config.cr
+++ b/src/hosted-danger/modules/server_config.cr
@@ -50,8 +50,6 @@ module HostedDanger
           ENV.delete(s.env)
         end
       end
-
-      p @@server_config_internal
     end
 
     def self.githubs : Array(GithubConfig)
@@ -71,7 +69,6 @@ module HostedDanger
     end
 
     def self.symbol_to_git_host(symbol : String) : String
-      p @@server_config_internal.not_nil!.githubs.find { |g| g.symbol == symbol }
       @@server_config_internal.not_nil!.githubs.find { |g| g.symbol == symbol }.not_nil!.host
     end
 

--- a/src/hosted-danger/modules/server_config.cr
+++ b/src/hosted-danger/modules/server_config.cr
@@ -50,6 +50,8 @@ module HostedDanger
           ENV.delete(s.env)
         end
       end
+
+      p @@server_config_internal
     end
 
     def self.githubs : Array(GithubConfig)
@@ -69,6 +71,7 @@ module HostedDanger
     end
 
     def self.symbol_to_git_host(symbol : String) : String
+      p @@server_config_internal.not_nil!.githubs.find { |g| g.symbol == symbol }
       @@server_config_internal.not_nil!.githubs.find { |g| g.symbol == symbol }.not_nil!.host
     end
 

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -166,9 +166,13 @@ module HostedDanger
     end
 
     def get_git_context(params : Hash(String, String)) : GitContext
+      p "point -1"
       symbol = params["symbol"]
+      p symbol
       git_host = ServerConfig.symbol_to_git_host(symbol)
+      p git_host
       access_token = access_token_from_git_host(git_host)
+      p access_token
 
       {
         symbol:       symbol,

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -84,7 +84,11 @@ module HostedDanger
       headers = rewrite_headers(context, git_context)
       resource = rewrite_resource(context, git_context)
 
+      p git_context
+
       res = HTTP::Client.get("#{api_base(git_context)}/#{resource}", headers)
+
+      p res
 
       write_headers(context, git_context, res)
 

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -8,7 +8,7 @@ module HostedDanger
 
     def rewrite_headers(context, git_context : GitContext) : HTTP::Headers
       override_headers = HTTP::Headers.new
-      override_headers["Host"] = git_context[:git_host] if context.request.headers.keys.includes?("Host")
+      override_headers["Host"] = git_context[:git_host] if context.request.headers.has_key?("Host")
       override_headers["Authorization"] = "token #{git_context[:access_token]}"
 
       h = context.request.headers.merge!(override_headers)

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -13,7 +13,9 @@ module HostedDanger
 
       h = context.request.headers.merge!(override_headers)
       h.delete("Accept-Encoding")
+      p "before delete #{h}"
       h.delete("Host")
+      p "after delete #{h}"
       h
     end
 
@@ -80,19 +82,19 @@ module HostedDanger
     end
 
     def proxy_get(context, params)
-      p context
-      p params
+      # p context
+      # p params
       git_context = get_git_context(params)
       headers = rewrite_headers(context, git_context)
       resource = rewrite_resource(context, git_context)
       p headers
-      p resource
-      p git_context
-      p "#{api_base(git_context)}/#{resource}"
+      # p resource
+      # p git_context
+      # p "#{api_base(git_context)}/#{resource}"
 
       res = HTTP::Client.get("#{api_base(git_context)}/#{resource}", headers)
 
-      p res
+      # p res
 
       write_headers(context, git_context, res)
 

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -82,11 +82,10 @@ module HostedDanger
       p context
       p params
       git_context = get_git_context(params)
-      p "point 0"
       headers = rewrite_headers(context, git_context)
-      p "point 1"
+      p headers
       resource = rewrite_resource(context, git_context)
-
+      p resource
       p git_context
 
       res = HTTP::Client.get("#{api_base(git_context)}/#{resource}", headers)

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -13,6 +13,7 @@ module HostedDanger
 
       h = context.request.headers.merge!(override_headers)
       h.delete("Accept-Encoding")
+      h.delete("Host")
       h
     end
 

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -13,6 +13,11 @@ module HostedDanger
 
       h = context.request.headers.merge!(override_headers)
       h.delete("Accept-Encoding")
+
+      p "----------------"
+      p context.request.headers.has_key?("Host")
+      p h
+
       h
     end
 

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -8,16 +8,11 @@ module HostedDanger
 
     def rewrite_headers(context, git_context : GitContext) : HTTP::Headers
       override_headers = HTTP::Headers.new
-      override_headers["Host"] = git_context[:git_host] if context.request.headers.has_key?("Host")
+      # override_headers["Host"] = git_context[:git_host]
       override_headers["Authorization"] = "token #{git_context[:access_token]}"
 
       h = context.request.headers.merge!(override_headers)
       h.delete("Accept-Encoding")
-
-      p "----------------"
-      p context.request.headers.has_key?("Host")
-      p h
-
       h
     end
 

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -79,9 +79,12 @@ module HostedDanger
     end
 
     def proxy_get(context, params)
+      p context
+      p params
       git_context = get_git_context(params)
-
+      p "point 0"
       headers = rewrite_headers(context, git_context)
+      p "point 1"
       resource = rewrite_resource(context, git_context)
 
       p git_context

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -8,7 +8,7 @@ module HostedDanger
 
     def rewrite_headers(context, git_context : GitContext) : HTTP::Headers
       override_headers = HTTP::Headers.new
-      override_headers["Host"] = git_context[:git_host]
+      # override_headers["Host"] = git_context[:git_host]
       override_headers["Authorization"] = "token #{git_context[:access_token]}"
 
       h = context.request.headers.merge!(override_headers)
@@ -83,10 +83,11 @@ module HostedDanger
       p params
       git_context = get_git_context(params)
       headers = rewrite_headers(context, git_context)
-      p headers
       resource = rewrite_resource(context, git_context)
+      p headers
       p resource
       p git_context
+      p "#{api_base(git_context)}/#{resource}"
 
       res = HTTP::Client.get("#{api_base(git_context)}/#{resource}", headers)
 

--- a/src/hosted-danger/server/git_proxy.cr
+++ b/src/hosted-danger/server/git_proxy.cr
@@ -8,14 +8,11 @@ module HostedDanger
 
     def rewrite_headers(context, git_context : GitContext) : HTTP::Headers
       override_headers = HTTP::Headers.new
-      # override_headers["Host"] = git_context[:git_host]
+      override_headers["Host"] = git_context[:git_host] if context.request.headers.keys.includes?("Host")
       override_headers["Authorization"] = "token #{git_context[:access_token]}"
 
       h = context.request.headers.merge!(override_headers)
       h.delete("Accept-Encoding")
-      p "before delete #{h}"
-      h.delete("Host")
-      p "after delete #{h}"
       h
     end
 
@@ -82,19 +79,11 @@ module HostedDanger
     end
 
     def proxy_get(context, params)
-      # p context
-      # p params
       git_context = get_git_context(params)
       headers = rewrite_headers(context, git_context)
       resource = rewrite_resource(context, git_context)
-      p headers
-      # p resource
-      # p git_context
-      # p "#{api_base(git_context)}/#{resource}"
 
       res = HTTP::Client.get("#{api_base(git_context)}/#{resource}", headers)
-
-      # p res
 
       write_headers(context, git_context, res)
 
@@ -169,13 +158,9 @@ module HostedDanger
     end
 
     def get_git_context(params : Hash(String, String)) : GitContext
-      p "point -1"
       symbol = params["symbol"]
-      p symbol
       git_host = ServerConfig.symbol_to_git_host(symbol)
-      p git_host
       access_token = access_token_from_git_host(git_host)
-      p access_token
 
       {
         symbol:       symbol,


### PR DESCRIPTION
It needs a bit more fixes to work well.
I did test at https://github.com/tbrand/hosted-danger-test/pull/2.
Now I can see the approve from Hosted Danger.

I don't know why github.com returns 'BadRequest' when its request puts a 'Host' header.
But it works well when remove it.
The 'Host' header might be required for enterprise one. (I'm not sure.)