### PR TITLE
Returning response body when do `slack.post`

### DIFF
--- a/src/hosted-danger/server/slack_proxy.cr
+++ b/src/hosted-danger/server/slack_proxy.cr
@@ -11,6 +11,7 @@ module HostedDanger
         res = HTTP::Client.post("https://slack.com/api/chat.postMessage", headers, payload)
 
         context.response.status_code = res.status_code
+        context.response.print res.body
       else
         context.response.status_code = 400
       end


### PR DESCRIPTION
Currently internal slack proxy drops the response body.
